### PR TITLE
Enable passing arguments into ggoutlier main function

### DIFF
--- a/ggoutlier.py
+++ b/ggoutlier.py
@@ -87,7 +87,7 @@ import pdfdocument
 import pylasfile
 
 ###########################################################################
-def main(cli_args):
+def main(cli_args=sys.argv[1:]):
 
 	iho = ggmbesstandard.sp44()
 	msg = str(iho.getordernames())
@@ -543,7 +543,7 @@ def	log(msg, error = False, printmsg=True):
 
 ###############################################################################
 if __name__ == "__main__":
-	main(sys.argv[1:])
+	main()
 
 	########################v#######################################################
 	# log("Statistical outlier removal")

--- a/ggoutlier.py
+++ b/ggoutlier.py
@@ -87,7 +87,7 @@ import pdfdocument
 import pylasfile
 
 ###########################################################################
-def main():
+def main(cli_args):
 
 	iho = ggmbesstandard.sp44()
 	msg = str(iho.getordernames())
@@ -104,7 +104,7 @@ def main():
 	parser.add_argument('-odir',		action='store', 		default="",			dest='odir')
 
 	matches = []
-	args = parser.parse_args()
+	args = parser.parse_args(cli_args)
 
 	if os.path.isfile(args.inputfile):
 		matches.append(args.inputfile)
@@ -543,7 +543,7 @@ def	log(msg, error = False, printmsg=True):
 
 ###############################################################################
 if __name__ == "__main__":
-	main()
+	main(sys.argv[1:])
 
 	########################v#######################################################
 	# log("Statistical outlier removal")


### PR DESCRIPTION
Change allows other applications to call the ggoutlier `main` function with an array that contains command line inputs.

The code in `ggoutlier.py` that calls the `main` function has been updated to get the command line options specified by the user and pass them into the call to `main`. This means there is no change to how the command line interface is used.