### PR TITLE
Include setup.py so that ggoutlier can be 'pip installed'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,36 @@
+from setuptools import setup
+
+setup(
+    name='ggoutlier',
+    version='0.0.1',
+    url='https://github.com/pktrigg/ggoutlier',
+    author=(
+        "pktrigg;"
+    ),
+    author_email=(
+        "pktrigg@gmail.com;"
+    ),
+    description=(
+        'Tool for detecting isolated or anomalous depth measurements in bathymetry data'
+    ),
+    entry_points={
+        "gui_scripts": [],
+        "console_scripts": [
+            'ggoutlier = ggoutlier:main',
+        ],
+    },
+    packages=[
+        '.',
+    ],
+    zip_safe=False,
+    package_data={},
+    install_requires=[
+        'reportlab',
+        'pyproj',
+        'pyshp',
+        'scikit-learn',
+        'rasterio',
+        'numpy',
+        'matplotlib'
+    ],
+)


### PR DESCRIPTION
This change adds a setup.py file so that ggoutlier can be installed with pip. It slightly simplifies the command line required to run, and makes the application much easier to package within other tools to use as a module.

Assuming the repo has been cloned, ggoutlier can be installed with

    pip install .

Or for a development environment

    pip install -e .

When installed it can be run with

    ggoutlier --help

Please review attributions, email address, name, etc included in this setup.py. Detail were added based on what was already publicly available in the repo.