### PR TITLE
Fix provision of input parameters, include pngs used by report in packaged

### DIFF
--- a/ggoutlier.py
+++ b/ggoutlier.py
@@ -139,7 +139,9 @@ def main(cli_args=sys.argv[1:]):
 	start_time = time.time() # time the process
 	for file in matches:
 		#make an output folder
-		args.odir = os.path.join(os.path.dirname(file), os.path.splitext(os.path.basename(file))[0] + "_GGOutlier_%s"% (time.strftime("%Y%m%d-%H%M%S")))
+		if not args.odir:
+			# assume a default output directory if none is provided via input arguments
+			args.odir = os.path.join(os.path.dirname(file), os.path.splitext(os.path.basename(file))[0] + "_GGOutlier_%s"% (time.strftime("%Y%m%d-%H%M%S")))
 		# args.odir = os.path.join(os.path.dirname(file), str("GGOutlier_%s" % (time.strftime("%Y%m%d-%H%M%S"))))
 		# if not os.path.isdir(args.odir):
 		# 	args.odir = os.path.join(os.path.dirname(file), args.odir)

--- a/ggoutlier.py
+++ b/ggoutlier.py
@@ -128,7 +128,7 @@ def main(cli_args=sys.argv[1:]):
 	#get the WKT from the TIF file and add it to the args so we can make available....
 	WKT = cloud2tif.getWKT(matches[0])
 	parser.add_argument('-wkt',		action='store', 		default=WKT,			dest='wkt')
-	args = parser.parse_args()
+	args = parser.parse_args(cli_args)
 	#load the python proj projection object library if the user has requested it
 	if len(args.epsg) == 0:
 		args.epsg = str(geodetic.wkt2epsg(wkt=WKT))

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,12 @@ setup(
         '.',
     ],
     zip_safe=False,
-    package_data={},
+    package_data={
+        "ggoutlier": [
+            "GGOutlierGIS.png",
+            "Guardian.png",
+        ]
+    },
     install_requires=[
         'reportlab',
         'pyproj',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     },
     packages=[
         '.',
-        'ggoutlier'
     ],
     zip_safe=False,
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     zip_safe=False,
     package_data={
-        "ggoutlier": [
+        "": [
             "GGOutlierGIS.png",
             "Guardian.png",
         ]

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     },
     packages=[
         '.',
+        'ggoutlier'
     ],
     zip_safe=False,
     package_data={


### PR DESCRIPTION
PR includes three changes to support its integration into QAX

The first is a fix for correctly using the parameters passed into the `main()` function instead of exclusively via the command line. GGOutlier makes two calls to `parser.parse_args(...)`, and the previous PR only updated the first call to this function. As a result the default input params were being used irrespective of what was provided to `main`. This fixes that.

The second adds a check for if the user provided a `odir` parameter (via input to `main` or cli argument) before overriding this parameter with a default output folder location. I believe this was the expected implementation.

Lastly to support packaging tools (pyinstaller in this case), the two png files embedded into the report are now included as `package_data`. This seems valid as these two files are required for the tool to run successfully. This doesn't impact the install/run process in any way.