### PR TITLE
Coordinate precision error

### DIFF
--- a/ggmbesstandard.py
+++ b/ggmbesstandard.py
@@ -173,8 +173,6 @@ class standard:
 			width = deltazarray.shape[1]
 			cols, rows = np.meshgrid(np.arange(width), np.arange(height))
 			xs, ys = rasterio.transform.xy(deltazsrc.transform, rows, cols)
-			xs = np.float32(xs)
-			ys = np.float32(ys)
 			x = np.array(xs).flatten()
 			y = np.array(ys).flatten()
 			# deltazarray[deltazarray==deltazNODATA] = -9999
@@ -211,7 +209,7 @@ class standard:
 		gc.collect()	
 
 		dz = deltaz.flatten()
-		xydz = np.stack((x,y,dz), axis=1, dtype=np.float32)
+		xydz = np.stack((x,y,dz), axis=1, dtype=np.float64)
 		#remove the values which are inliers
 		xydz = xydz[np.all(xydz > 0.0, axis=1)]
 


### PR DESCRIPTION
This is to resolve the coordinate displacement issue described at

https://github.com/ausseabed/qax/issues/34

The coordinates will now retain the float64 precision which will prevent point displacements thereby preventing cases where incorrect pixels were being retrieved due to coordinate precision error.

Sample case:

```python
>>> import rasterio
>>> ds = rasterio.open("teste_qax.tif")
>>> data = ds.read(1)
>>> xf32, yf32 = 687445.8750, 7467638.0000  # coordinate resulting from cast to float32
>>> xf64, yf64 = 687445.8750, 7467638.125  # coordinate when retaining float64
>>> ~ds.transform * (xf32, yf32)
(41.5, 602.0)
>>> data[602, 41]
np.float32(-3.4028235e+38)
>>> ~ds.transform * (xf64, yf64)
(41.5, 601.5)
>>> data[601, 41]
np.float32(-15.623333)
```

![pixel-offsets-f32-f64-fix](https://github.com/user-attachments/assets/1aa8d1ab-1be9-407b-981f-ee8a60b9f0c4)

The red triangles are displaced due to the loss in precision, and the green rhombus locations are those retaining float64 precision.
