### PR TITLE
Fix: correct outlier/inlier filtering

### DIFF
--- a/ggmbesstandard.py
+++ b/ggmbesstandard.py
@@ -213,7 +213,7 @@ class standard:
 		dz = deltaz.flatten()
 		xydz = np.stack((x,y,dz), axis=1, dtype=np.float32)
 		#remove the values which are inliers
-		xydz = xydz[np.all(xydz > 0.0, axis=1)]
+		xydz = xydz[xydz[:, 2] > 0]
 
 		# Write to tif, using the same profile as the source
 		# log("Writing outliers to raster file: %s" % (outfilename))


### PR DESCRIPTION
This small patch is to correct the inlier/outlier filtering.

The original code would apply a `> 0` filter to remove inliers. However, the inclusion of `numpy.all` over `axis=1` meant that for this shaped array, all elements across the row needed to be `> 0` in order to be retained. This includes the `X` and `Y` coordinated axes.  Meaning, that any `X` or `Y` coordinate containing a negative value would remove the whole row.

For example:

```python
>>> import numpy
>>> x = [1, -1, 1, 1, -1]
>>> y = [2, 2, -2, 2, -2]
>>> z = [3, 3, 3, -3, -3]
>>> xyz = numpy.stack((x, y, z), axis=1)
>>> xyz
array([[ 1,  2,  3],
       [-1,  2,  3],
       [ 1, -2,  3],
       [ 1,  2, -3],
       [-1, -2, -3]])
>>> xyz.shape
(5, 3)
>>> xyz[numpy.all(xyz > 0, axis=1)]
array([[1, 2, 3]])
```

Whereas, it should only be applied to the `dz` values contained in the last column as indicated by the comment `#remove the values which are inliers`.

eg:

```python
>>> xyz[xyz[:, 2] > 0]
array([[ 1,  2,  3],
       [-1,  2,  3],
       [ 1, -2,  3]])
```